### PR TITLE
Update the reducer function in log_prob_jaxpr

### DIFF
--- a/oryx/core/interpreters/log_prob.py
+++ b/oryx/core/interpreters/log_prob.py
@@ -102,7 +102,7 @@ def log_prob_jaxpr(jaxpr, constcells, flat_incells, flat_outcells):
       # We are unable to compute a log_prob for this primitive.
       return failed_log_prob
     if new_log_prob is not None:
-      cells = [env.read(var) for var in eqn.outvars]
+      cells = [env.read(var) for var in eqn.invars]
       ildjs = sum([cell.ildj.sum() for cell in cells if cell.top()])
       return curr_log_prob + new_log_prob + ildjs
     return curr_log_prob

--- a/oryx/core/interpreters/log_prob_test.py
+++ b/oryx/core/interpreters/log_prob_test.py
@@ -128,6 +128,15 @@ class LogProbTest(test_util.TestCase):
     f_lp = log_prob(f)
     self.assertEqual(f_lp(0.1, 1.0), bd.Normal(0., 1.).log_prob(-0.9))
 
+  def test_multiple_equations(self):
+
+      def f(rng):
+          return jax.jit(random_normal)(rng) * 2
+
+      dist = bd.Normal(0., 2.)
+      f_lp = log_prob(f)
+      self.assertEqual(f_lp(0.1), dist.log_prob(0.1))
+
   def test_log_prob_in_call(self):
 
     def f(rng):


### PR DESCRIPTION
This change in the `reducer` function inside `log_prob_jaxpr` produces the correct result when a jaxpr has more than one equation. A test case was also added that didn't pass before, but passes after the change. This is an attempt to solve #12.