### PR TITLE
Add InverseAndILDJ rule for lax.copy_p

### DIFF
--- a/oryx/core/interpreters/inverse/rules.py
+++ b/oryx/core/interpreters/inverse/rules.py
@@ -253,6 +253,25 @@ def convert_element_type_ildj(incells, outcells, *, new_dtype, **params):
 ildj_registry[lax.convert_element_type_p] = convert_element_type_ildj
 
 
+def copy_ildj(incells, outcells, **params):
+  """InverseAndILDJ rule for the ``copy_p`` primitive.
+
+  ``copy`` is an identity operation: it returns its input unchanged. It is
+  therefore its own inverse, and contributes 0 to the log-determinant since it
+  does not change volume. Some JAX trace paths (e.g. under ``jax.jit``) emit
+  ``copy_p``, so without this rule the inverse interpreter raises
+  ``NotImplementedError`` on otherwise-invertible programs.
+  """
+  incell, = incells
+  outcell, = outcells
+  if incell.top() and not outcell.top():
+    outcells = [InverseAndILDJ.new(lax.copy_p.bind(incell.val, **params))]
+  elif outcell.top() and not incell.top():
+    incells = [InverseAndILDJ.new(outcell.val)]
+  return incells, outcells, None
+ildj_registry[lax.copy_p] = copy_ildj
+
+
 # Monkey patching JAX so we can define custom, more numerically stable inverses.
 jax.scipy.special.expit = custom_inverse(jax.scipy.special.expit)
 jax.scipy.special.logit = custom_inverse(jax.scipy.special.logit)


### PR DESCRIPTION
## What

Adds an `InverseAndILDJ` rule for the `lax.copy_p` primitive in `oryx/core/interpreters/inverse/rules.py`.

## Why

`copy_p` is an identity primitive that some JAX trace paths emit (notably under `jax.jit`). The inverse interpreter has no rule for it today, so `core.inverse` / `core.ildj` raise `NotImplementedError` on programs that are otherwise perfectly invertible — the only blocker being a stray `copy`.

## The rule

`copy` returns its input unchanged, so:
- it is its own inverse, and
- it contributes **0** to the log-determinant (no change of volume).

The rule is the trivial identity mirroring the existing `convert_element_type_ildj` pattern:

```python
def copy_ildj(incells, outcells, **params):
  incell, = incells
  outcell, = outcells
  if incell.top() and not outcell.top():
    outcells = [InverseAndILDJ.new(lax.copy_p.bind(incell.val, **params))]
  elif outcell.top() and not incell.top():
    incells = [InverseAndILDJ.new(outcell.val)]
  return incells, outcells, None
ildj_registry[lax.copy_p] = copy_ildj
```

This lets inverse-based workflows run on jitted programs that would otherwise fail solely because of a `copy_p` in the trace. Happy to add a focused test if you'd like one.